### PR TITLE
feat(dot_git-commit-template): add `<scope>` portion

### DIFF
--- a/private_dot_config/git/dot_git-commit-template
+++ b/private_dot_config/git/dot_git-commit-template
@@ -1,4 +1,4 @@
-# <type>: (If applied, this commit will...) <subject> (Max 50 char)
+# <type>(<scope>): (If applied, this commit will...) <subject> (Max 50 char)
 # |<----  Try to Limit to a Max of 50 char  ---->|
 
 
@@ -21,6 +21,8 @@
 #   revert:   for reverts, revert: <old subject>; state reverted hash in body
 #   style:    formatting, missing semi colons, etc; no code meaning change
 #   test:     adding or refactoring tests; no production code change
+#
+# Scope refers to the file, directory, or system that is being modified.
 #
 # Follow the type(scope) with an '!' to indicate a breaking change.
 # Example: refactor(api)!: remove the accident-prone delete_all button


### PR DESCRIPTION
From this in [Slack](https://numbersstationgroup.slack.com/archives/D03JBNNHCTU/p1654584572519769):

> Also, I noticed [the conventional commits template](https://raw.githubusercontent.com/lukehsiao/dotfiles/master/private_dot_config/git/dot_git-commit-template) you linked to in [the Engineering Workflow doc](https://docs.google.com/document/d/13DGNSq5VnICpq-6x8p1JsnemcnA15ObZjTybWYI3DVI/edit#) doesn't include the (<scope>): thingy. Should I be including that? Or are we omitting it in NS repos?